### PR TITLE
[backend] Add base_hostname value

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -47,6 +47,7 @@ The following table lists the configurable parameters of the `backend` chart and
 
 |            Parameter             |                   Description                   |                Default                 |
 |----------------------------------|-------------------------------------------------|----------------------------------------|
+| base_hostname                    | Base hostname to apply to the URLs shortened    | `http://localhost:8080`                |
 | deployment.replicas              | Number of replicas for the backend              | `1`                                    |
 | image.repository                 | Image repository                                | `ghcr.io/webengineeringgroupi/backend` |
 | image.tag                        | Image tag                                       | `master`                               |

--- a/charts/backend/templates/configmap.yaml
+++ b/charts/backend/templates/configmap.yaml
@@ -6,3 +6,4 @@ data:
   database_host: {{ .Values.database.postgresqlHost | default (printf "%s-%s" .Release.Name "database") }}
   database_name: {{ .Values.database.postgresqlDatabase }}
   database_ssl_mode: {{ .Values.database.ssl_mode }} # (disable, allow, prefer, require, verify-ca, verify-full) https://www.postgresql.org/docs/9.1/libpq-ssl.html
+  base_hostname: {{ .Values.base_hostname }}

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -102,6 +102,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-google-safe-browsing
                   key: apiKey
+            - name: BASE_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-backend
+                  key: base_hostname
       restartPolicy: Always
   selector:
     matchLabels:

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -1,3 +1,6 @@
+# Base hostname to apply to the URLs shortened
+base_hostname: http://localhost:8080
+
 deployment:
   # Number of replicas for the backend
   replicas: 1


### PR DESCRIPTION
<!--
Please fill the required information below:
-->
## What this PR does / why we need it:

Adds the base hostname value to configure the BASE_DOMAIN environment variable, which configures the domain for the URLs shortened.

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname] Change to apply`)
- [x] PR only contains changes for one chart
