### PR TITLE
[backend] Add multiple ingress host and paths generation and pod annotations

### DIFF
--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backend/Chart.yaml
+++ b/charts/backend/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/backend/README.md
+++ b/charts/backend/README.md
@@ -45,37 +45,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the `backend` chart and their default values.
 
-|            Parameter             |                   Description                   |                Default                 |
-|----------------------------------|-------------------------------------------------|----------------------------------------|
-| base_hostname                    | Base hostname to apply to the URLs shortened    | `http://localhost:8080`                |
-| deployment.replicas              | Number of replicas for the backend              | `1`                                    |
-| image.repository                 | Image repository                                | `ghcr.io/webengineeringgroupi/backend` |
-| image.tag                        | Image tag                                       | `master`                               |
-| image.pullPolicy                 | Image Pull Policy (Always, IfNotPresent, Never) | `Always`                               |
-| service.http.create              | Whether to create or not the HTTP service       | `true`                                 |
-| service.http.type                | Type for the service for the HTTP backend       | `ClusterIP`                            |
-| service.http.port                | Port for the HTTP endpoint                      | `8080`                                 |
-| service.grpc.create              | Whether to create or not the gRPC service       | `true`                                 |
-| service.grpc.type                | Type of the service for the gRPC backend        | `ClusterIP`                            |
-| service.grpc.port                | Port for the gRPC endpoint                      | `8081`                                 |
-| database.deploy                  | Whether to deploy or not the postgres database  | `true`                                 |
-| database.postgresqlUsername      | User for the database                           | `postgres`                             |
-| database.postgresqlPassword      | Password for the database                       | `""`                                   |
-| database.postgresqlDatabase      | Name of the database                            | `postgres`                             |
-| database.postgresqlHost          | Service of the postgres database                | ``                                     |
-| database.ssl_mode                | SSL mode of the Postgres DB                     | `disable`                              |
-| database.service.port            | Port of the database                            | `5432`                                 |
-| integrations.safebrowsing.apiKey | API Key for the Google SafeBrowsing integration | ``                                     |
-| ingress.http.enabled             | Whether to deploy the HTTP ingress or not       | `true`                                 |
-| ingress.http.host                | Host setting for the HTTP ingress               | ``                                     |
-| ingress.http.path                | Path to match for the HTTP ingress              | `/`                                    |
-| ingress.http.pathType            | Type of path to match (Prefix, Exact)           | `Prefix`                               |
-| ingress.http.extra_annotations   | Extra annotations for the HTTP ingress          | `{}`                                   |
-| ingress.grpc.enabled             | Whether to deploy the gRPC ingress or not       | `true`                                 |
-| ingress.grpc.host                | Host setting for the gRPC ingress               | ``                                     |
-| ingress.grpc.path                | Path to match for the gRPC ingress              | `/`                                    |
-| ingress.grpc.pathType            | Type of path to match (Prefix, Exact)           | `Prefix`                               |
-| ingress.grpc.extra_annotations   | Extra annotations for the gRPC ingress          | `{}`                                   |
+|            Parameter             |                   Description                   |                                                                            Default                                                                            |
+|----------------------------------|-------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| base_hostname                    | Base hostname to apply to the URLs shortened    | `http://localhost:8080`                                                                                                                                       |
+| deployment.replicas              | Number of replicas for the backend              | `1`                                                                                                                                                           |
+| deployment.podAnnotations        | Pod annotations                                 | `{"prometheus.io/path":"/metrics","prometheus.io/port":"8080","prometheus.io/scheme":"http","prometheus.io/scrape":"true","sidecar.istio.io/inject":"false"}` |
+| image.repository                 | Image repository                                | `ghcr.io/webengineeringgroupi/backend`                                                                                                                        |
+| image.tag                        | Image tag                                       | `master`                                                                                                                                                      |
+| image.pullPolicy                 | Image Pull Policy (Always, IfNotPresent, Never) | `Always`                                                                                                                                                      |
+| service.http.create              | Whether to create or not the HTTP service       | `true`                                                                                                                                                        |
+| service.http.type                | Type for the service for the HTTP backend       | `ClusterIP`                                                                                                                                                   |
+| service.http.port                | Port for the HTTP endpoint                      | `8080`                                                                                                                                                        |
+| service.grpc.create              | Whether to create or not the gRPC service       | `true`                                                                                                                                                        |
+| service.grpc.type                | Type of the service for the gRPC backend        | `ClusterIP`                                                                                                                                                   |
+| service.grpc.port                | Port for the gRPC endpoint                      | `8081`                                                                                                                                                        |
+| database.deploy                  | Whether to deploy or not the postgres database  | `true`                                                                                                                                                        |
+| database.postgresqlUsername      | User for the database                           | `postgres`                                                                                                                                                    |
+| database.postgresqlPassword      | Password for the database                       | `""`                                                                                                                                                          |
+| database.postgresqlDatabase      | Name of the database                            | `postgres`                                                                                                                                                    |
+| database.postgresqlHost          | Service of the postgres database                | ``                                                                                                                                                            |
+| database.ssl_mode                | SSL mode of the Postgres DB                     | `disable`                                                                                                                                                     |
+| database.service.port            | Port of the database                            | `5432`                                                                                                                                                        |
+| integrations.safebrowsing.apiKey | API Key for the Google SafeBrowsing integration | ``                                                                                                                                                            |
+| ingress.http.enabled             | Whether to deploy the HTTP ingress or not       | `true`                                                                                                                                                        |
+| ingress.http.hosts               | Host setting for the HTTP ingress               | `[""]`                                                                                                                                                        |
+| ingress.http.paths               | Paths to match for the HTTP ingress             | `[{"path":"/","type":"Prefix"}]`                                                                                                                              |
+| ingress.http.extra_annotations   | Extra annotations for the HTTP ingress          | `{}`                                                                                                                                                          |
+| ingress.grpc.enabled             | Whether to deploy the gRPC ingress or not       | `true`                                                                                                                                                        |
+| ingress.grpc.hosts               | Host setting for the gRPC ingress               | `[""]`                                                                                                                                                        |
+| ingress.grpc.paths               | Paths to match for the gRPC ingress             | `[{"path":"/","type":"Prefix"}]`                                                                                                                              |
+| ingress.grpc.extra_annotations   | Extra annotations for the gRPC ingress          | `{}`                                                                                                                                                          |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/charts/backend/templates/deployment.yaml
+++ b/charts/backend/templates/deployment.yaml
@@ -9,6 +9,9 @@ spec:
   template:
     metadata:
       name: {{ .Release.Name }}-backend
+      {{- with .Values.deployment.podAnnotations }}
+      annotations: {{ toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ .Release.Name }}-backend
     spec:

--- a/charts/backend/templates/ingress.yaml
+++ b/charts/backend/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.http.enabled }}
+{{- if (and .Values.ingress.http.enabled .Values.service.http.create)}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -9,18 +9,22 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.http.host }}
+    {{- range .Values.ingress.http.hosts }}
+    - host: {{ . }}
       http:
         paths:
-          - path: {{ .Values.ingress.http.path }}
-            pathType: {{ .Values.ingress.http.pathType }}
+          {{- range $.Values.ingress.http.paths }}
+          - path: {{ .path }}
+            pathType: {{ .type | default "Prefix" }}
             backend:
               service:
-                name: {{ .Release.Name }}-http
+                name: {{ $.Release.Name }}-http
                 port:
                   name: http
-  {{- end }}
-  {{- if .Values.ingress.grpc.enabled }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- if (and .Values.ingress.grpc.enabled .Values.service.grpc.create)}}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -31,14 +35,18 @@ metadata:
   {{- end }}
 spec:
   rules:
-    - host: {{ .Values.ingress.grpc.host }}
+    {{- range .Values.ingress.grpc.hosts }}
+    - host: {{ . }}
       http:
         paths:
-          - path: {{ .Values.ingress.grpc.path }}
-            pathType: {{ .Values.ingress.grpc.pathType }}
+          {{- range $.Values.ingress.grpc.paths }}
+          - path: {{ .path }}
+            pathType: {{ .type | default "Prefix" }}
             backend:
               service:
-                name: {{ .Release.Name }}-grpc
+                name: {{ $.Release.Name }}-grpc
                 port:
                   name: grpc
-  {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/backend/values.yaml
+++ b/charts/backend/values.yaml
@@ -4,6 +4,13 @@ base_hostname: http://localhost:8080
 deployment:
   # Number of replicas for the backend
   replicas: 1
+  # Pod annotations
+  podAnnotations:  # +doc-gen:break
+    prometheus.io/scrape: "true"
+    prometheus.io/path: "/metrics"
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: "http"
+    sidecar.istio.io/inject: "false"
 
 image:
   # Image repository
@@ -56,21 +63,23 @@ ingress:
     # Whether to deploy the HTTP ingress or not
     enabled: true
     # Host setting for the HTTP ingress
-    host:
-    # Path to match for the HTTP ingress
-    path: /
-    # Type of path to match (Prefix, Exact)
-    pathType: Prefix
+    hosts:  # +doc-gen:break
+      - ""
+    # Paths to match for the HTTP ingress
+    paths:  # +doc-gen:break
+      - path: /
+        type: Prefix
     # Extra annotations for the HTTP ingress
     extra_annotations: {}
   grpc:
     # Whether to deploy the gRPC ingress or not
     enabled: true
     # Host setting for the gRPC ingress
-    host:
-    # Path to match for the gRPC ingress
-    path: /
-    # Type of path to match (Prefix, Exact)
-    pathType: Prefix
+    hosts:  # +doc-gen:break
+    - ""
+    # Paths to match for the gRPC ingress
+    paths:  # +doc-gen:break
+      - path: /
+        type: Prefix
     # Extra annotations for the gRPC ingress
     extra_annotations: {}


### PR DESCRIPTION
<!--
Please fill the required information below:
-->
## What this PR does / why we need it:
Adds multiple ingress host and paths generation and pod annotations so the deployment can be scraped with Prometheus.
## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[mychartname] Change to apply`)
- [x] PR only contains changes for one chart
